### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/nervox/__init__.py
+++ b/nervox/__init__.py
@@ -22,4 +22,3 @@ Email: rameez.ismaeel@gmail.com
 
 from .trainer import *
 from .exporter import *
-

--- a/nervox/callbacks/callback.py
+++ b/nervox/callbacks/callback.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from abc import abstractmethod
 from typing import final, Sequence, Mapping, Any
 
+
 class Callback:
     """Abstract base class used to build new callbacks.
     Callbacks can be passed to nervox trainer through `spin`, in order to hook into the

--- a/nervox/data/transforms.py
+++ b/nervox/data/transforms.py
@@ -17,7 +17,8 @@
 import tensorflow as tf
 from typing import Union, Tuple
 from nervox.utils import capture_params
-#import tensorflow_addons as tfa
+
+# import tensorflow_addons as tfa
 from nervox.utils import capture_params
 
 # Aliases
@@ -306,19 +307,19 @@ class RandomVerticalFlip:
         return dataset.map(self.transform, num_parallel_calls=self.num_parallel_calls)
 
 
-#class RandomCutout:
+# class RandomCutout:
 #    @capture_params
 #    def __init__(self, cutout_size, input_key='image',
 #                 num_parallel_calls=tf.data.AUTOTUNE) -> None:
 #        self.key = input_key
 #        self.cutout_size = cutout_size
 #        self.num_parallel_calls = num_parallel_calls
-#    
+#
 #    def transform(self, batch):
 #        output_image = tfa.image.random_cutout(batch[self.key], self.cutout_size)
 #        batch.update({self.key: output_image})
 #        return batch
-#    
+#
 #    def __call__(self, dataset):
 #        return dataset.map(self.transform, self.num_parallel_calls)
 

--- a/nervox/modules/axis_norm.py
+++ b/nervox/modules/axis_norm.py
@@ -142,8 +142,8 @@ class LayerNorm(Module):
 
         # Turns slice definition into list of axis
         if isinstance(self._axis, slice):
-          axes = tuple(range(self._rank))
-          self._axis = axes[self._axis]
+            axes = tuple(range(self._rank))
+            self._axis = axes[self._axis]
 
         # Create scale and offset variables
         if self._channel_index == -1:

--- a/nervox/modules/bias.py
+++ b/nervox/modules/bias.py
@@ -104,7 +104,9 @@ class Bias(Module):
             bias_shape = calculate_bias_shape(input_shape, self.dims)
             input_size = input_shape[1:]
             self.input_size = input_size
-            self._bias = tf.Variable(self.initializer(bias_shape, self.dtype), name="bias")
+            self._bias = tf.Variable(
+                self.initializer(bias_shape, self.dtype), name="bias"
+            )
 
     def compute(self, inputs: tf.Tensor, multiplier: Optional[float] = None):
         """Adds bias to `inputs` and optionally multiplies by `multiplier`.

--- a/nervox/modules/conv.py
+++ b/nervox/modules/conv.py
@@ -13,10 +13,10 @@
 #
 # Author(s): Rameez Ismail
 # Email(s):  rameez.ismaeel@gmail.com
-# 
-# This code is adapted from Sonnet by DeepMind: 
+#
+# This code is adapted from Sonnet by DeepMind:
 # https://github.com/deepmind/sonnet
-# The project is licensed under the Apache-2.0. 
+# The project is licensed under the Apache-2.0.
 # You may obtain a copy of the license at:
 # http://www.apache.org/licenses/LICENSE-2.0
 
@@ -126,9 +126,7 @@ class ConvND(Module):
         self.output_channels = output_channels
 
         try:
-            kernel_size = tuple(
-                np.broadcast_to(kernel_size, (num_spatial_dims,))
-            )
+            kernel_size = tuple(np.broadcast_to(kernel_size, (num_spatial_dims,)))
         except ValueError as e:
             logger.error(str(e))
             raise ValueError(
@@ -500,7 +498,6 @@ class Conv1D(ConvND):
             name,
             dtype,
         )
-
 
 
 if __name__ == "__main__":

--- a/nervox/modules/vision/decoders.py
+++ b/nervox/modules/vision/decoders.py
@@ -139,41 +139,65 @@ class MLDecoder(tf.keras.Model):
         x = self.dropout_readout(x, training=training)
         logits = self.read_out_layer(x)
         return logits
-    
-    
+
+
 class MLDecoderAttention(tf.keras.Model):
     @capture_params
-    def __init__(self, d_model: int, num_heads=8, dim_feedforward=2048, dropout_rate=0.1,
-                 data_format='channels_last', layer_norm_eps=1e-5) -> None:
+    def __init__(
+        self,
+        d_model: int,
+        num_heads=8,
+        dim_feedforward=2048,
+        dropout_rate=0.1,
+        data_format="channels_last",
+        layer_norm_eps=1e-5,
+    ) -> None:
         super().__init__()
-        axis = -1 if data_format == 'channels_last' else 1
-        self.multihead_attn = tf.keras.layers.MultiHeadAttention(num_heads, key_dim=d_model//num_heads,
-                                                                 dropout=dropout_rate)
+        axis = -1 if data_format == "channels_last" else 1
+        self.multihead_attn = tf.keras.layers.MultiHeadAttention(
+            num_heads, key_dim=d_model // num_heads, dropout=dropout_rate
+        )
         # Implementation of Feedforward model
         self.dense_1 = tf.keras.layers.Dense(dim_feedforward)
         self.dense_2 = tf.keras.layers.Dense(d_model)
         self.dropout = tf.keras.layers.Dropout(dropout_rate)
-        
-        self.layer_norm_1 = tf.keras.layers.LayerNormalization(axis=axis, epsilon=layer_norm_eps)
-        self.layer_norm_2 = tf.keras.layers.LayerNormalization(axis=axis, epsilon=layer_norm_eps)
-        self.layer_norm_3 = tf.keras.layers.LayerNormalization(axis=axis, epsilon=layer_norm_eps)
-        
+
+        self.layer_norm_1 = tf.keras.layers.LayerNormalization(
+            axis=axis, epsilon=layer_norm_eps
+        )
+        self.layer_norm_2 = tf.keras.layers.LayerNormalization(
+            axis=axis, epsilon=layer_norm_eps
+        )
+        self.layer_norm_3 = tf.keras.layers.LayerNormalization(
+            axis=axis, epsilon=layer_norm_eps
+        )
+
         self.dropout_1 = tf.keras.layers.Dropout(dropout_rate)
         self.dropout_2 = tf.keras.layers.Dropout(dropout_rate)
         self.dropout_3 = tf.keras.layers.Dropout(dropout_rate)
-    
-    def call(self, targets: tf.Tensor, memory: tf.Tensor,
-             attention_mask: Optional[tf.Tensor] = None,
-             training: bool = None) -> tf.Tensor:
+
+    def call(
+        self,
+        targets: tf.Tensor,
+        memory: tf.Tensor,
+        attention_mask: Optional[tf.Tensor] = None,
+        training: bool = None,
+    ) -> tf.Tensor:
         x_a = self.layer_norm_1(targets + self.dropout_1(targets, training=training))
-        x_b = self.multihead_attn(targets, memory, attention_mask=attention_mask, training=training)
+        x_b = self.multihead_attn(
+            targets, memory, attention_mask=attention_mask, training=training
+        )
         x_a = self.layer_norm_2(x_a + self.dropout_2(x_b, training=training))
-        x_b = self.dense_2(self.dropout(tf.nn.relu(self.dense_1(x_a)), training=training))
+        x_b = self.dense_2(
+            self.dropout(tf.nn.relu(self.dense_1(x_a)), training=training)
+        )
         out = self.layer_norm_3(x_a + self.dropout_3(x_b, training=training))
         return out
-    
+
     def to_json(self):
-        params = getattr(self, 'params', {})
-        return {'module': self.__module__,
-                'class': type(self).__name__,
-                'config': dict(params)}
+        params = getattr(self, "params", {})
+        return {
+            "module": self.__module__,
+            "class": type(self).__name__,
+            "config": dict(params),
+        }

--- a/nervox/modules/vision/encoders.py
+++ b/nervox/modules/vision/encoders.py
@@ -25,7 +25,7 @@ from nervox.utils import capture_params
 
 
 class ConvnetEncoder(tf.keras.Model):
-    """ This class creates a simple convolution encoder network which should achieve ~85% accuracy on CIFAR-10
+    """This class creates a simple convolution encoder network which should achieve ~85% accuracy on CIFAR-10
      dataset when learning the default classification objective in the nervox. This model is mainly used to test
      and verify the health of the nervox framework. This script also serves as a canonical form of defining a
      neural network model within the nervox framework.
@@ -35,81 +35,98 @@ class ConvnetEncoder(tf.keras.Model):
         'batch_size': 64,
         'strategy': 'explicit_supervision',
         'learning_rates': {0: 1e-2, 30: 1e-3},
-        
+
     Arguments:
     conv_layers:            A list of k elements providing number of filters for k convolution layers
     neurons_per_layer:      A list of k elements providing number of neurons for k dense layers
     output_classes:         number of output classes.
     data_format:            "channels_first" or "channels_last"
     """
-    
+
     def get_config(self):
-        return getattr(self, 'params', dict())
-    
+        return getattr(self, "params", dict())
+
     @capture_params
-    def __init__(self,
-                 conv_layers=(64, 128, 128, 128),
-                 data_format='channels_last',
-                 dropout_rate=0.25
-                 ):
+    def __init__(
+        self,
+        conv_layers=(64, 128, 128, 128),
+        data_format="channels_last",
+        dropout_rate=0.25,
+    ):
         super().__init__()
-        axis = -1 if data_format == 'channels_last' else 1
+        axis = -1 if data_format == "channels_last" else 1
         self.convolution_layers = list()
         self.pooling_layers = list()
         self.dense_layers = list()
         self.dropout_layers = list()
         self.batch_norm_layers = list()
-        
+
         assert len(conv_layers) >= 2
-        
-        self.convolution_layers.append(tf.keras.layers.Conv2D(conv_layers[0],
-                                                              kernel_size=(3, 3),
-                                                              padding='same',
-                                                              data_format=data_format
-                                                              ))
-        
-        self.convolution_layers.append(tf.keras.layers.Conv2D(conv_layers[1],
-                                                              kernel_size=(3, 3),
-                                                              padding='same',
-                                                              data_format=data_format
-                                                              ))
-        
-        self.pooling_layers.append(tf.keras.layers.Conv2D(conv_layers[1],
-                                                          kernel_size=(2, 2),
-                                                          strides=(2, 2),
-                                                          data_format=data_format
-                                                          ))
-        
+
+        self.convolution_layers.append(
+            tf.keras.layers.Conv2D(
+                conv_layers[0],
+                kernel_size=(3, 3),
+                padding="same",
+                data_format=data_format,
+            )
+        )
+
+        self.convolution_layers.append(
+            tf.keras.layers.Conv2D(
+                conv_layers[1],
+                kernel_size=(3, 3),
+                padding="same",
+                data_format=data_format,
+            )
+        )
+
+        self.pooling_layers.append(
+            tf.keras.layers.Conv2D(
+                conv_layers[1],
+                kernel_size=(2, 2),
+                strides=(2, 2),
+                data_format=data_format,
+            )
+        )
+
         self.dropout_layers.append(tf.keras.layers.Dropout(dropout_rate))
-        
+
         for i in range(2, len(conv_layers)):
-            self.convolution_layers.append(tf.keras.layers.Conv2D(conv_layers[i],
-                                                                  kernel_size=(3, 3),
-                                                                  padding='same',
-                                                                  data_format=data_format,
-                                                                  use_bias=False,
-                                                                  ))
-            
+            self.convolution_layers.append(
+                tf.keras.layers.Conv2D(
+                    conv_layers[i],
+                    kernel_size=(3, 3),
+                    padding="same",
+                    data_format=data_format,
+                    use_bias=False,
+                )
+            )
+
             self.batch_norm_layers.append(tf.keras.layers.BatchNormalization(axis=axis))
-            
-            self.pooling_layers.append(tf.keras.layers.Conv2D(conv_layers[i],
-                                                              kernel_size=(2, 2),
-                                                              strides=(2, 2),
-                                                              data_format=data_format
-                                                              ))
+
+            self.pooling_layers.append(
+                tf.keras.layers.Conv2D(
+                    conv_layers[i],
+                    kernel_size=(2, 2),
+                    strides=(2, 2),
+                    data_format=data_format,
+                )
+            )
             self.dropout_layers.append(tf.keras.layers.Dropout(dropout_rate))
-    
+
     def call(self, x, training=True):
         x = self.convolution_layers[0](x)
         x = self.convolution_layers[1](tf.nn.relu(x))
         x = self.pooling_layers[0](tf.nn.relu(x))
         x = self.dropout_layers[0](x, training=training)
         # zip the remaining layers
-        zipped_layers = zip(self.convolution_layers[2:],
-                            self.batch_norm_layers,
-                            self.pooling_layers[1:],
-                            self.dropout_layers[1:]
-                            )
+        zipped_layers = zip(
+            self.convolution_layers[2:],
+            self.batch_norm_layers,
+            self.pooling_layers[1:],
+            self.dropout_layers[1:],
+        )
         # Apply convolution layer tuples
         for convolution, batch_norm, pooling, dropout in zipped_layers:
             x = convolution(x)

--- a/nervox/utils/initializers.py
+++ b/nervox/utils/initializers.py
@@ -77,7 +77,7 @@ class Zeros(Initializer):
 
 class Ones(Initializer):
     """Initializer that generates tensors initialized to 1."""
-    
+
     def __call__(self, shape: types.ShapeLike, dtype: tf.DType) -> tf.Tensor:
         dtype = _as_numerical_dtype(dtype)
         return tf.ones(shape, dtype)

--- a/nervox/utils/serializers.py
+++ b/nervox/utils/serializers.py
@@ -36,6 +36,7 @@ def serializer_dtype(obj: tf.DType):
         "__repr__": repr(obj),
     }
 
+
 def serializer_slice(obj: slice):
     if not isinstance(obj, slice):
         raise TypeError(
@@ -44,9 +45,9 @@ def serializer_slice(obj: slice):
             "\nReceived: {type(obj).__name__}"
         )
     return {
-        "__class__": 'slice',
-        "__module__": 'builtins',
-        "__init__": {'_args': (obj.start, obj.stop, obj.step)},
+        "__class__": "slice",
+        "__module__": "builtins",
+        "__init__": {"_args": (obj.start, obj.stop, obj.step)},
         "__repr__": repr(obj),
     }
 
@@ -86,10 +87,7 @@ class SerializerRegistry:
     SerializerRegistry.register(my_custom_serializer)\n"
     """
 
-    _serializers = {
-        tf.DType: serializer_dtype,
-        slice:  serializer_slice
-    }
+    _serializers = {tf.DType: serializer_dtype, slice: serializer_slice}
 
     @classmethod
     def register(cls, serializer: callable):

--- a/pursuits/workflow_cifar10.py
+++ b/pursuits/workflow_cifar10.py
@@ -86,7 +86,7 @@ class Cifar10(FlowSpec):
         from nervox.data.transforms import Normalize, OneHotLabels
         from nervox.data import DataStream
         from nervox.utils import VerbosityLevel
-        from nervox.modules.vision.decoders  import GlobalAvgPoolDecoder
+        from nervox.modules.vision.decoders import GlobalAvgPoolDecoder
 
         # os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
         # os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"

--- a/tests/metrics/test_commons.py
+++ b/tests/metrics/test_commons.py
@@ -87,12 +87,17 @@ class TestMeanMetrics(tf.test.TestCase):
         )
         mean.update(values)
         self.assertAllClose(expectation, mean.result())
-        
+
         mean = Mean(axis=1, keepdims=True)
-        expectation = [[[10., 20.]], [[10, 20]], [[5, 5]], [[10., 15.]]]
-        values = tf.constant([[[11., 17.4], [9., 22.6]], [[9, 22.6], [11., 17.4]],
-                              [[2, 8.], [8., 2.]], [[15, 22], [5., 8.]]
-                              ])
+        expectation = [[[10.0, 20.0]], [[10, 20]], [[5, 5]], [[10.0, 15.0]]]
+        values = tf.constant(
+            [
+                [[11.0, 17.4], [9.0, 22.6]],
+                [[9, 22.6], [11.0, 17.4]],
+                [[2, 8.0], [8.0, 2.0]],
+                [[15, 22], [5.0, 8.0]],
+            ]
+        )
         mean.update(values)
         self.assertAllClose(expectation, mean.result())
 

--- a/tests/modules/test_axis_norm.py
+++ b/tests/modules/test_axis_norm.py
@@ -20,298 +20,312 @@ from absl.testing import parameterized
 from nervox.utils import initializers
 from nervox.modules import axis_norm
 
+
 class LayerNormTest(tf.test.TestCase, parameterized.TestCase):
 
-  def testSimpleCase(self):
-    layer = axis_norm.LayerNorm([1, 2], create_scale=False, create_offset=False)
-    inputs = tf.ones([2, 3, 3, 5])
-
-    outputs = layer(inputs).numpy()
-    for x in np.nditer(outputs):
-      self.assertEqual(x, 0.0)
-
-  def testSimpleCaseVar(self):
-    layer = axis_norm.LayerNorm([1, 2],
-                                create_scale=True,
-                                create_offset=True,
-                                scale_init=initializers.Constant(0.5),
-                                offset_init=initializers.Constant(2.0))
-
-    inputs = tf.ones([2, 3, 3, 5])
-
-    outputs = layer(inputs).numpy()
-    for x in np.nditer(outputs):
-      self.assertEqual(x, 2.0)
-
-  def testSimpleCaseNCHWVar(self):
-    layer = axis_norm.LayerNorm([1, 2],
-                                create_scale=True,
-                                create_offset=True,
-                                scale_init=initializers.Constant(0.5),
-                                offset_init=initializers.Constant(2.0),
-                                data_format="NCHW")
-
-    inputs = tf.ones([2, 5, 3, 3])
-
-    outputs = layer(inputs).numpy()
-    for x in np.nditer(outputs):
-      self.assertEqual(x, 2.0)
-
-  def testDataFormatAgnosticVar(self):
-    c_last_layer = axis_norm.LayerNorm([1, 2],
-                                       create_scale=True,
-                                       create_offset=True)
-    c_first_layer = axis_norm.LayerNorm([2, 3],
-                                        create_scale=True,
-                                        create_offset=True,
-                                        data_format="NCHW")
-
-    inputs = tf.random.uniform([3, 4, 4, 5], 0, 10)
-
-    c_last_output = c_last_layer(inputs)
-    inputs = tf.transpose(inputs, [0, 3, 1, 2])
-    c_first_output = c_first_layer(inputs)
-    c_first_output = tf.transpose(c_first_output, [0, 2, 3, 1])
-
-    self.assertAllClose(c_last_output.numpy(), c_first_output.numpy())
-
-  def testSimpleCaseTensor(self):
-    layer = axis_norm.LayerNorm([1, 2], create_scale=False, create_offset=False)
-
-    inputs = tf.ones([2, 3, 3, 5])
-    scale = tf.constant(0.5, shape=(5,))
-    offset = tf.constant(2.0, shape=(5,))
-
-    outputs = layer(inputs, scale=scale, offset=offset).numpy()
-    for x in np.nditer(outputs):
-      self.assertEqual(x, 2.0)
-
-  def testSimpleCaseNCHWTensor(self):
-    layer = axis_norm.LayerNorm([1, 2],
-                                data_format="NCHW",
-                                create_scale=False,
-                                create_offset=False)
-
-    inputs = tf.ones([2, 5, 3, 3])
-    scale = tf.constant(0.5, shape=(5, 1, 1))
-    offset = tf.constant(2.0, shape=(5, 1, 1))
-
-    outputs = layer(inputs, scale=scale, offset=offset).numpy()
-    for x in np.nditer(outputs):
-      self.assertEqual(x, 2.0)
-
-  def testDataFormatAgnosticTensor(self):
-    c_last_layer = axis_norm.LayerNorm([1, 2],
-                                       create_scale=False,
-                                       create_offset=False)
-    c_first_layer = axis_norm.LayerNorm([2, 3],
-                                        data_format="NCHW",
-                                        create_scale=False,
-                                        create_offset=False)
-
-    inputs = tf.random.uniform([3, 4, 4, 5], 0, 10)
-    scale = tf.random.normal((5,), mean=1.0)
-    offset = tf.random.normal((5,))
-
-    c_last_output = c_last_layer(inputs, scale=scale, offset=offset)
-    inputs = tf.transpose(inputs, [0, 3, 1, 2])
-    scale = tf.reshape(scale, (5, 1, 1))
-    offset = tf.reshape(offset, (5, 1, 1))
-    c_first_output = c_first_layer(inputs, scale=scale, offset=offset)
-    c_first_output = tf.transpose(c_first_output, [0, 2, 3, 1])
-
-    self.assertAllClose(c_last_output.numpy(), c_first_output.numpy())
-
-  @parameterized.parameters("NHW", "HWC", "channel_last")
-  def testInvalidDataFormat(self, data_format):
-    with self.assertRaisesRegex(
-        ValueError,
-        "Unable to extract channel information from '{}'.".format(data_format)):
-      axis_norm.LayerNorm(
-          3, data_format=data_format, create_scale=False, create_offset=False)
-
-  @parameterized.parameters("NCHW", "NCW", "channels_first")
-  def testValidDataFormatChannelsFirst(self, data_format):
-    test = axis_norm.LayerNorm(
-        3, data_format=data_format, create_scale=False, create_offset=False)
-
-    self.assertEqual(test._channel_index, 1)
-
-  @parameterized.parameters("NHWC", "NWC", "channels_last")
-  def testValidDataFormatChannelsLast(self, data_format):
-    test = axis_norm.LayerNorm(
-        3, data_format=data_format, create_scale=False, create_offset=False)
-
-    self.assertEqual(test._channel_index, -1)
-
-  @parameterized.named_parameters(("String", "foo"), ("ListString", ["foo"]))
-  def testInvalidAxis(self, axis):
-    with self.assertRaisesRegex(
-        ValueError, "`axis` should be an int, slice or iterable of ints."):
-      axis_norm.LayerNorm(axis, create_scale=False, create_offset=False)
-
-  def testNoScaleAndInitProvided(self):
-    with self.assertRaisesRegex(
-        ValueError, "Cannot set `scale_init` if `create_scale=False`."):
-      axis_norm.LayerNorm(
-          3,
-          create_scale=False,
-          create_offset=True,
-          scale_init=initializers.Ones())
-
-  def testNoOffsetBetaInitProvided(self):
-    with self.assertRaisesRegex(
-        ValueError, "Cannot set `offset_init` if `create_offset=False`."):
-      axis_norm.LayerNorm(
-          3,
-          create_scale=True,
-          create_offset=False,
-          offset_init=initializers.Zeros())
-
-  def testCreateScaleAndScaleProvided(self):
-    layer = axis_norm.LayerNorm([2], create_scale=True, create_offset=False)
-
-    with self.assertRaisesRegex(
-        ValueError, "Cannot pass `scale` at call time if `create_scale=True`."):
-      layer(tf.ones([2, 3, 4]), scale=tf.ones([4]))
-
-  def testCreateOffsetAndOffsetProvided(self):
-    layer = axis_norm.LayerNorm([2], create_offset=True, create_scale=False)
-
-    with self.assertRaisesRegex(
-        ValueError,
-        "Cannot pass `offset` at call time if `create_offset=True`."):
-      layer(tf.ones([2, 3, 4]), offset=tf.ones([4]))
-
-  def testSliceAxis(self):
-    slice_layer = axis_norm.LayerNorm(
-        slice(1, -1), create_scale=False, create_offset=False)
-    axis_layer = axis_norm.LayerNorm((1, 2),
-                                     create_scale=False,
-                                     create_offset=False)
-
-    inputs = tf.random.uniform([3, 4, 4, 5], 0, 10)
-    scale = tf.random.normal((5,), mean=1.0)
-    offset = tf.random.normal((5,))
-
-    slice_outputs = slice_layer(inputs, scale=scale, offset=offset)
-    axis_outputs = axis_layer(inputs, scale=scale, offset=offset)
-
-    self.assertAllEqual(slice_outputs.numpy(), axis_outputs.numpy())
-
-  def testRankChanges(self):
-    layer = axis_norm.LayerNorm((1, 2), create_scale=False, create_offset=False)
-
-    inputs = tf.ones([2, 3, 3, 5])
-    scale = tf.constant(0.5, shape=(5,))
-    offset = tf.constant(2.0, shape=(5,))
-
-    layer(inputs, scale=scale, offset=offset)
-
-    with self.assertRaisesRegex(
-        ValueError,
-        "The rank of the inputs cannot change between calls, the original"):
-      layer(tf.ones([2, 3, 3, 4, 5]), scale=scale, offset=offset)
-
-  def testWorksWithFunction(self):
-    layer = axis_norm.LayerNorm((1, 2), create_scale=False, create_offset=False)
-    function_layer = tf.function(layer)
-
-    inputs = tf.ones([2, 3, 3, 5])
-    scale = tf.constant(0.5, shape=(5,))
-    offset = tf.constant(2.0, shape=(5,))
-
-    outputs = layer(inputs, scale=scale, offset=offset)
-    function_outputs = function_layer(inputs, scale=scale, offset=offset)
-
-    self.assertAllEqual(outputs.numpy(), function_outputs.numpy())
-
-  def testShapeAgnostic(self):
-    layer = axis_norm.LayerNorm((1, 2), create_scale=False, create_offset=False)
-    inputs_spec = tf.TensorSpec([None, None, None, None], dtype=tf.float32)
-    params_spec = tf.TensorSpec([None], dtype=tf.float32)
-    function_layer = tf.function(layer).get_concrete_function(
-        inputs_spec, scale=params_spec, offset=params_spec)
-
-    scale = tf.constant(0.5, shape=(5,))
-    offset = tf.constant(2.0, shape=(5,))
-
-    outputs = function_layer(tf.ones([2, 3, 3, 5]), scale=scale, offset=offset)
-    self.assertEqual(outputs.shape, [2, 3, 3, 5])
-    for x in np.nditer(outputs):
-      self.assertEqual(x, 2.0)
-
-    scale = tf.constant(0.5, shape=(3,))
-    offset = tf.constant(2.0, shape=(3,))
-
-    outputs = function_layer(tf.ones([3, 4, 6, 3]), scale=scale, offset=offset)
-    self.assertEqual(outputs.shape, [3, 4, 6, 3])
-    for x in np.nditer(outputs):
-      self.assertEqual(x, 2.0)
-
-  def test5DDataFormatAgnostic(self):
-    c_last_layer = axis_norm.LayerNorm([1, 2, 3],
-                                       create_scale=False,
-                                       create_offset=False)
-    c_first_layer = axis_norm.LayerNorm([2, 3, 4],
-                                        create_scale=False,
-                                        create_offset=False,
-                                        data_format="NCDHW")
-
-    inputs = tf.random.uniform([3, 4, 4, 4, 5], 0, 10)
-    scale = tf.random.normal((5,), mean=1.0)
-    offset = tf.random.normal((5,))
-
-    c_last_output = c_last_layer(inputs, scale=scale, offset=offset)
-    inputs = tf.transpose(inputs, [0, 4, 1, 2, 3])
-    scale = tf.reshape(scale, [-1, 1, 1, 1])
-    offset = tf.reshape(offset, [-1, 1, 1, 1])
-    c_first_output = c_first_layer(inputs, scale=scale, offset=offset)
-    c_first_output = tf.transpose(c_first_output, [0, 2, 3, 4, 1])
-
-    self.assertAllClose(
-        c_last_output.numpy(), c_first_output.numpy(), atol=1e-5, rtol=1e-5)
-
-  def test3DDataFormatAgnostic(self):
-    c_last_layer = axis_norm.LayerNorm([1],
-                                       create_scale=False,
-                                       create_offset=False)
-    c_first_layer = axis_norm.LayerNorm([2],
-                                        create_scale=False,
-                                        create_offset=False,
-                                        data_format="NCW")
-
-    inputs = tf.random.uniform([3, 4, 5], 0, 10)
-    scale = tf.random.normal((5,), mean=1.0)
-    offset = tf.random.normal((5,))
-
-    c_last_output = c_last_layer(inputs, scale=scale, offset=offset)
-    inputs = tf.transpose(inputs, [0, 2, 1])
-    scale = tf.reshape(scale, [-1, 1])
-    offset = tf.reshape(offset, [-1, 1])
-    c_first_output = c_first_layer(inputs, scale=scale, offset=offset)
-    c_first_output = tf.transpose(c_first_output, [0, 2, 1])
-
-    self.assertAllClose(
-        c_last_output.numpy(), c_first_output.numpy(), atol=1e-5, rtol=1e-5)
-
-  def testInstanceNormCorrectAxis(self):
-    layer = axis_norm.InstanceNorm(create_scale=True, create_offset=True)
-
-    inputs = tf.ones([3, 4, 5, 6])
-    layer(inputs)
-
-    self.assertEqual(layer._axis, (1, 2))
-
-  def testInstanceNormCorrectNCW(self):
-    layer = axis_norm.InstanceNorm(
-        create_scale=True, create_offset=True, data_format="channels_first")
-
-    inputs = tf.ones([3, 4, 5, 6])
-    layer(inputs)
-
-    self.assertEqual(layer._axis, (2, 3))
+    def testSimpleCase(self):
+        layer = axis_norm.LayerNorm([1, 2], create_scale=False, create_offset=False)
+        inputs = tf.ones([2, 3, 3, 5])
+
+        outputs = layer(inputs).numpy()
+        for x in np.nditer(outputs):
+            self.assertEqual(x, 0.0)
+
+    def testSimpleCaseVar(self):
+        layer = axis_norm.LayerNorm(
+            [1, 2],
+            create_scale=True,
+            create_offset=True,
+            scale_init=initializers.Constant(0.5),
+            offset_init=initializers.Constant(2.0),
+        )
+
+        inputs = tf.ones([2, 3, 3, 5])
+
+        outputs = layer(inputs).numpy()
+        for x in np.nditer(outputs):
+            self.assertEqual(x, 2.0)
+
+    def testSimpleCaseNCHWVar(self):
+        layer = axis_norm.LayerNorm(
+            [1, 2],
+            create_scale=True,
+            create_offset=True,
+            scale_init=initializers.Constant(0.5),
+            offset_init=initializers.Constant(2.0),
+            data_format="NCHW",
+        )
+
+        inputs = tf.ones([2, 5, 3, 3])
+
+        outputs = layer(inputs).numpy()
+        for x in np.nditer(outputs):
+            self.assertEqual(x, 2.0)
+
+    def testDataFormatAgnosticVar(self):
+        c_last_layer = axis_norm.LayerNorm(
+            [1, 2], create_scale=True, create_offset=True
+        )
+        c_first_layer = axis_norm.LayerNorm(
+            [2, 3], create_scale=True, create_offset=True, data_format="NCHW"
+        )
+
+        inputs = tf.random.uniform([3, 4, 4, 5], 0, 10)
+
+        c_last_output = c_last_layer(inputs)
+        inputs = tf.transpose(inputs, [0, 3, 1, 2])
+        c_first_output = c_first_layer(inputs)
+        c_first_output = tf.transpose(c_first_output, [0, 2, 3, 1])
+
+        self.assertAllClose(c_last_output.numpy(), c_first_output.numpy())
+
+    def testSimpleCaseTensor(self):
+        layer = axis_norm.LayerNorm([1, 2], create_scale=False, create_offset=False)
+
+        inputs = tf.ones([2, 3, 3, 5])
+        scale = tf.constant(0.5, shape=(5,))
+        offset = tf.constant(2.0, shape=(5,))
+
+        outputs = layer(inputs, scale=scale, offset=offset).numpy()
+        for x in np.nditer(outputs):
+            self.assertEqual(x, 2.0)
+
+    def testSimpleCaseNCHWTensor(self):
+        layer = axis_norm.LayerNorm(
+            [1, 2], data_format="NCHW", create_scale=False, create_offset=False
+        )
+
+        inputs = tf.ones([2, 5, 3, 3])
+        scale = tf.constant(0.5, shape=(5, 1, 1))
+        offset = tf.constant(2.0, shape=(5, 1, 1))
+
+        outputs = layer(inputs, scale=scale, offset=offset).numpy()
+        for x in np.nditer(outputs):
+            self.assertEqual(x, 2.0)
+
+    def testDataFormatAgnosticTensor(self):
+        c_last_layer = axis_norm.LayerNorm(
+            [1, 2], create_scale=False, create_offset=False
+        )
+        c_first_layer = axis_norm.LayerNorm(
+            [2, 3], data_format="NCHW", create_scale=False, create_offset=False
+        )
+
+        inputs = tf.random.uniform([3, 4, 4, 5], 0, 10)
+        scale = tf.random.normal((5,), mean=1.0)
+        offset = tf.random.normal((5,))
+
+        c_last_output = c_last_layer(inputs, scale=scale, offset=offset)
+        inputs = tf.transpose(inputs, [0, 3, 1, 2])
+        scale = tf.reshape(scale, (5, 1, 1))
+        offset = tf.reshape(offset, (5, 1, 1))
+        c_first_output = c_first_layer(inputs, scale=scale, offset=offset)
+        c_first_output = tf.transpose(c_first_output, [0, 2, 3, 1])
+
+        self.assertAllClose(c_last_output.numpy(), c_first_output.numpy())
+
+    @parameterized.parameters("NHW", "HWC", "channel_last")
+    def testInvalidDataFormat(self, data_format):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unable to extract channel information from '{}'.".format(data_format),
+        ):
+            axis_norm.LayerNorm(
+                3, data_format=data_format, create_scale=False, create_offset=False
+            )
+
+    @parameterized.parameters("NCHW", "NCW", "channels_first")
+    def testValidDataFormatChannelsFirst(self, data_format):
+        test = axis_norm.LayerNorm(
+            3, data_format=data_format, create_scale=False, create_offset=False
+        )
+
+        self.assertEqual(test._channel_index, 1)
+
+    @parameterized.parameters("NHWC", "NWC", "channels_last")
+    def testValidDataFormatChannelsLast(self, data_format):
+        test = axis_norm.LayerNorm(
+            3, data_format=data_format, create_scale=False, create_offset=False
+        )
+
+        self.assertEqual(test._channel_index, -1)
+
+    @parameterized.named_parameters(("String", "foo"), ("ListString", ["foo"]))
+    def testInvalidAxis(self, axis):
+        with self.assertRaisesRegex(
+            ValueError, "`axis` should be an int, slice or iterable of ints."
+        ):
+            axis_norm.LayerNorm(axis, create_scale=False, create_offset=False)
+
+    def testNoScaleAndInitProvided(self):
+        with self.assertRaisesRegex(
+            ValueError, "Cannot set `scale_init` if `create_scale=False`."
+        ):
+            axis_norm.LayerNorm(
+                3,
+                create_scale=False,
+                create_offset=True,
+                scale_init=initializers.Ones(),
+            )
+
+    def testNoOffsetBetaInitProvided(self):
+        with self.assertRaisesRegex(
+            ValueError, "Cannot set `offset_init` if `create_offset=False`."
+        ):
+            axis_norm.LayerNorm(
+                3,
+                create_scale=True,
+                create_offset=False,
+                offset_init=initializers.Zeros(),
+            )
+
+    def testCreateScaleAndScaleProvided(self):
+        layer = axis_norm.LayerNorm([2], create_scale=True, create_offset=False)
+
+        with self.assertRaisesRegex(
+            ValueError, "Cannot pass `scale` at call time if `create_scale=True`."
+        ):
+            layer(tf.ones([2, 3, 4]), scale=tf.ones([4]))
+
+    def testCreateOffsetAndOffsetProvided(self):
+        layer = axis_norm.LayerNorm([2], create_offset=True, create_scale=False)
+
+        with self.assertRaisesRegex(
+            ValueError, "Cannot pass `offset` at call time if `create_offset=True`."
+        ):
+            layer(tf.ones([2, 3, 4]), offset=tf.ones([4]))
+
+    def testSliceAxis(self):
+        slice_layer = axis_norm.LayerNorm(
+            slice(1, -1), create_scale=False, create_offset=False
+        )
+        axis_layer = axis_norm.LayerNorm(
+            (1, 2), create_scale=False, create_offset=False
+        )
+
+        inputs = tf.random.uniform([3, 4, 4, 5], 0, 10)
+        scale = tf.random.normal((5,), mean=1.0)
+        offset = tf.random.normal((5,))
+
+        slice_outputs = slice_layer(inputs, scale=scale, offset=offset)
+        axis_outputs = axis_layer(inputs, scale=scale, offset=offset)
+
+        self.assertAllEqual(slice_outputs.numpy(), axis_outputs.numpy())
+
+    def testRankChanges(self):
+        layer = axis_norm.LayerNorm((1, 2), create_scale=False, create_offset=False)
+
+        inputs = tf.ones([2, 3, 3, 5])
+        scale = tf.constant(0.5, shape=(5,))
+        offset = tf.constant(2.0, shape=(5,))
+
+        layer(inputs, scale=scale, offset=offset)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "The rank of the inputs cannot change between calls, the original",
+        ):
+            layer(tf.ones([2, 3, 3, 4, 5]), scale=scale, offset=offset)
+
+    def testWorksWithFunction(self):
+        layer = axis_norm.LayerNorm((1, 2), create_scale=False, create_offset=False)
+        function_layer = tf.function(layer)
+
+        inputs = tf.ones([2, 3, 3, 5])
+        scale = tf.constant(0.5, shape=(5,))
+        offset = tf.constant(2.0, shape=(5,))
+
+        outputs = layer(inputs, scale=scale, offset=offset)
+        function_outputs = function_layer(inputs, scale=scale, offset=offset)
+
+        self.assertAllEqual(outputs.numpy(), function_outputs.numpy())
+
+    def testShapeAgnostic(self):
+        layer = axis_norm.LayerNorm((1, 2), create_scale=False, create_offset=False)
+        inputs_spec = tf.TensorSpec([None, None, None, None], dtype=tf.float32)
+        params_spec = tf.TensorSpec([None], dtype=tf.float32)
+        function_layer = tf.function(layer).get_concrete_function(
+            inputs_spec, scale=params_spec, offset=params_spec
+        )
+
+        scale = tf.constant(0.5, shape=(5,))
+        offset = tf.constant(2.0, shape=(5,))
+
+        outputs = function_layer(tf.ones([2, 3, 3, 5]), scale=scale, offset=offset)
+        self.assertEqual(outputs.shape, [2, 3, 3, 5])
+        for x in np.nditer(outputs):
+            self.assertEqual(x, 2.0)
+
+        scale = tf.constant(0.5, shape=(3,))
+        offset = tf.constant(2.0, shape=(3,))
+
+        outputs = function_layer(tf.ones([3, 4, 6, 3]), scale=scale, offset=offset)
+        self.assertEqual(outputs.shape, [3, 4, 6, 3])
+        for x in np.nditer(outputs):
+            self.assertEqual(x, 2.0)
+
+    def test5DDataFormatAgnostic(self):
+        c_last_layer = axis_norm.LayerNorm(
+            [1, 2, 3], create_scale=False, create_offset=False
+        )
+        c_first_layer = axis_norm.LayerNorm(
+            [2, 3, 4], create_scale=False, create_offset=False, data_format="NCDHW"
+        )
+
+        inputs = tf.random.uniform([3, 4, 4, 4, 5], 0, 10)
+        scale = tf.random.normal((5,), mean=1.0)
+        offset = tf.random.normal((5,))
+
+        c_last_output = c_last_layer(inputs, scale=scale, offset=offset)
+        inputs = tf.transpose(inputs, [0, 4, 1, 2, 3])
+        scale = tf.reshape(scale, [-1, 1, 1, 1])
+        offset = tf.reshape(offset, [-1, 1, 1, 1])
+        c_first_output = c_first_layer(inputs, scale=scale, offset=offset)
+        c_first_output = tf.transpose(c_first_output, [0, 2, 3, 4, 1])
+
+        self.assertAllClose(
+            c_last_output.numpy(), c_first_output.numpy(), atol=1e-5, rtol=1e-5
+        )
+
+    def test3DDataFormatAgnostic(self):
+        c_last_layer = axis_norm.LayerNorm([1], create_scale=False, create_offset=False)
+        c_first_layer = axis_norm.LayerNorm(
+            [2], create_scale=False, create_offset=False, data_format="NCW"
+        )
+
+        inputs = tf.random.uniform([3, 4, 5], 0, 10)
+        scale = tf.random.normal((5,), mean=1.0)
+        offset = tf.random.normal((5,))
+
+        c_last_output = c_last_layer(inputs, scale=scale, offset=offset)
+        inputs = tf.transpose(inputs, [0, 2, 1])
+        scale = tf.reshape(scale, [-1, 1])
+        offset = tf.reshape(offset, [-1, 1])
+        c_first_output = c_first_layer(inputs, scale=scale, offset=offset)
+        c_first_output = tf.transpose(c_first_output, [0, 2, 1])
+
+        self.assertAllClose(
+            c_last_output.numpy(), c_first_output.numpy(), atol=1e-5, rtol=1e-5
+        )
+
+    def testInstanceNormCorrectAxis(self):
+        layer = axis_norm.InstanceNorm(create_scale=True, create_offset=True)
+
+        inputs = tf.ones([3, 4, 5, 6])
+        layer(inputs)
+
+        self.assertEqual(layer._axis, (1, 2))
+
+    def testInstanceNormCorrectNCW(self):
+        layer = axis_norm.InstanceNorm(
+            create_scale=True, create_offset=True, data_format="channels_first"
+        )
+
+        inputs = tf.ones([3, 4, 5, 6])
+        layer(inputs)
+
+        self.assertEqual(layer._axis, (2, 3))
 
 
 if __name__ == "__main__":
-  tf.test.main()
+    tf.test.main()

--- a/tests/modules/test_bias.py
+++ b/tests/modules/test_bias.py
@@ -13,10 +13,10 @@
 #
 # Author(s): Rameez Ismail
 # Email(s):  rameez.ismaeel@gmail.com
-# 
-# This code is adapted from Sonnet by DeepMind: 
+#
+# This code is adapted from Sonnet by DeepMind:
 # https://github.com/deepmind/sonnet
-# The project is licensed under the Apache-2.0. 
+# The project is licensed under the Apache-2.0.
 # You may obtain a copy of the license at:
 # http://www.apache.org/licenses/LICENSE-2.0
 
@@ -24,55 +24,56 @@
 
 import tensorflow as tf
 from nervox.modules.bias import Bias
-from nervox.utils import initializers 
+from nervox.utils import initializers
 
 
 class BiasTest(tf.test.TestCase):
 
-  def test_dims_scalar(self):
-    mod = Bias(dims=())
-    mod(tf.ones([1, 2, 3, 4]))
-    self.assertEmpty(mod._bias.shape)
+    def test_dims_scalar(self):
+        mod = Bias(dims=())
+        mod(tf.ones([1, 2, 3, 4]))
+        self.assertEmpty(mod._bias.shape)
 
-  def test_dims_custom(self):
-    b, d1, d2, d3 = range(1, 5)
-    mod = Bias(dims=[1, 3])
-    out = mod(tf.ones([b, d1, d2, d3]))
-    self.assertEqual(mod._bias.shape, [d1, 1, d3])
-    self.assertEqual(out.shape, [b, d1, d2, d3])
+    def test_dims_custom(self):
+        b, d1, d2, d3 = range(1, 5)
+        mod = Bias(dims=[1, 3])
+        out = mod(tf.ones([b, d1, d2, d3]))
+        self.assertEqual(mod._bias.shape, [d1, 1, d3])
+        self.assertEqual(out.shape, [b, d1, d2, d3])
 
-  def test_dims_negative_out_of_order(self):
-    mod = Bias(dims=[-1, -2])
-    mod(tf.ones([1, 2, 3]))
-    self.assertEqual(mod._bias.shape, [2, 3])
+    def test_dims_negative_out_of_order(self):
+        mod = Bias(dims=[-1, -2])
+        mod(tf.ones([1, 2, 3]))
+        self.assertEqual(mod._bias.shape, [2, 3])
 
-  def test_dims_invalid(self):
-    mod = Bias(dims=[1, 5])
-    with self.assertRaisesRegex(ValueError,
-                                "5 .* out of range for input of rank 3"):
-      mod(tf.ones([1, 2, 3]))
+    def test_dims_invalid(self):
+        mod = Bias(dims=[1, 5])
+        with self.assertRaisesRegex(
+            ValueError, "5 .* out of range for input of rank 3"
+        ):
+            mod(tf.ones([1, 2, 3]))
 
-  def test_b_init_defaults_to_zeros(self):
-    mod = Bias()
-    mod(tf.ones([1, 1]))
-    self.assertAllEqual(mod._bias.read_value(), tf.zeros_like(mod._bias))
+    def test_b_init_defaults_to_zeros(self):
+        mod = Bias()
+        mod(tf.ones([1, 1]))
+        self.assertAllEqual(mod._bias.read_value(), tf.zeros_like(mod._bias))
 
-  def test_b_init_custom(self):
-    mod = Bias(initializer=initializers.Ones())
-    mod(tf.ones([1, 1]))
-    self.assertAllEqual(mod._bias.read_value(), tf.ones_like(mod._bias))
+    def test_b_init_custom(self):
+        mod = Bias(initializer=initializers.Ones())
+        mod(tf.ones([1, 1]))
+        self.assertAllEqual(mod._bias.read_value(), tf.ones_like(mod._bias))
 
-  def test_name(self):
-    mod = Bias(name="foo")
-    self.assertEqual(mod.name, "foo")
-    mod(tf.ones([1, 1]))
-    self.assertEqual(mod._bias.name, "foo/bias:0")
+    def test_name(self):
+        mod = Bias(name="foo")
+        self.assertEqual(mod.name, "foo")
+        mod(tf.ones([1, 1]))
+        self.assertEqual(mod._bias.name, "foo/bias:0")
 
-  def test_multiplier(self):
-    mod = Bias(initializer=initializers.Ones())
-    out = mod(tf.ones([1, 1]), multiplier=-1)
-    self.assertAllEqual(tf.reduce_sum(out), 0)
+    def test_multiplier(self):
+        mod = Bias(initializer=initializers.Ones())
+        out = mod(tf.ones([1, 1]), multiplier=-1)
+        self.assertAllEqual(tf.reduce_sum(out), 0)
 
 
 if __name__ == "__main__":
-  tf.test.main()
+    tf.test.main()


### PR DESCRIPTION
There appear to be some python formatting errors in e68e9b2cbd44487116600399d486a750934b0608. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.